### PR TITLE
fix rollback on workers?

### DIFF
--- a/src/lib/rollbar.ts
+++ b/src/lib/rollbar.ts
@@ -12,6 +12,9 @@ export const rollbar = new Rollbar({
 	captureUnhandledRejections: !isServer,
 	// Disable browser monitoring on server
 	addErrorContext: !isServer,
+	// avoid cloudflare workers problem see
+	// https://github.com/rollbar/rollbar.js/issues/1129
+	autoInstrument: false,
 	environment: import.meta.env.PROD ? 'production' : 'development',
 	enabled: import.meta.env.PROD, // Only enable in production
 	payload: {


### PR DESCRIPTION
This pull request introduces a small but important change to the Rollbar configuration in `src/lib/rollbar.ts`. The change disables automatic instrumentation to address a known issue with Cloudflare Workers.

* [`src/lib/rollbar.ts`](diffhunk://#diff-23b22b7d69776d4e17c2a05041efdfcec379e688dd53afbfa8243b38275a2c48R15-R17): Added `autoInstrument: false` to the Rollbar configuration to avoid problems with Cloudflare Workers as described in the Rollbar.js GitHub issue #1129.