### PR TITLE
fix ingredient sync

### DIFF
--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -105,7 +105,9 @@ export const persistenceContext = {
 	},
 	async startSync() {
 		isSyncing = true;
-		return await syncManager.startAll();
+		console.log('Starting sync for all collections');
+		await syncManager.startAll();
+		await syncManager.isReady();
 	},
 	async stopSync() {
 		isSyncing = false;
@@ -159,11 +161,6 @@ export const persistenceContext = {
 			// Upsert ingredients that are in the mixture
 			// This will update existing ones and insert new ones
 			for (const ingredient of serialized) {
-				const existing = existingIngredients.find((ing) => ing.id === ingredient.id);
-				if (existing && deepEqual(existing.item, ingredient.item)) {
-					// No change, skip
-					continue;
-				}
 				// Upsert the ingredient
 				ingredientsCollections.replaceOne(
 					{ id: ingredient.id },

--- a/src/lib/sync-manager.ts
+++ b/src/lib/sync-manager.ts
@@ -1,5 +1,6 @@
 import { SyncManager } from '@signaldb/sync';
 import { EventEmitter } from '@signaldb/core';
+import createIndexedDBAdapter from '@signaldb/indexeddb';
 
 const errorEmitter = new EventEmitter();
 errorEmitter.on('error', (message: string) => {
@@ -10,6 +11,7 @@ errorEmitter.on('error', (message: string) => {
 export const syncManager = new SyncManager({
 	autostart: false,
 	debounceTime: 1000,
+	persistenceAdapter: (name) => createIndexedDBAdapter(name),
 	pull: async ({ apiPath }) => {
 		console.log('Fetching cloud files from:', apiPath);
 		const resp = await fetch(apiPath);


### PR DESCRIPTION
This pull request introduces enhancements to the persistence and synchronization logic, primarily focusing on improved logging, optimization of database operations, and the addition of a new persistence adapter. Below are the key changes grouped by theme:

### Improvements to Synchronization Logic:
* Added a log message to indicate the start of synchronization and ensured the `syncManager` is ready after starting synchronization in the `startSync` method of `persistenceContext` (`src/lib/persistence.ts`).

### Bugfix:
* Removed sync-preventing checks for existing ingredients before upserting them in the `persistenceContext` (`src/lib/persistence.ts`).

### Integration of IndexedDB Adapter:
* Imported `createIndexedDBAdapter` from `@signaldb/indexeddb` in `sync-manager.ts` to enable the use of IndexedDB as a persistence adapter (`src/lib/sync-manager.ts`).
* Configured the `SyncManager` to use the new IndexedDB persistence adapter by adding a `persistenceAdapter` option (`src/lib/sync-manager.ts`).